### PR TITLE
fix(FEC-11654): Broadpeak Smartlib for specific LG WebOS versions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,8 +10,6 @@
     [
       "@babel/preset-env",
       {
-        "useBuiltIns": "usage",
-        "corejs": 3,
         "loose": true,
         "bugfixes": true,
         "targets": {

--- a/flow-typed/modules/broadpeak-smartlib-v3.js
+++ b/flow-typed/modules/broadpeak-smartlib-v3.js
@@ -1,4 +1,4 @@
 // @flow
-declare module '@broadpeak/smartlib-v3' {
+declare module '@broadpeak/smartlib-v3-nopolyfill' {
   declare module.exports: any;
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     ]
   },
   "dependencies": {
-    "@broadpeak/smartlib-v3": "^3.2.0-3317"
+    "@broadpeak/smartlib-v3-nopolyfill": "^3.3.5.3791"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     ]
   },
   "dependencies": {
-    "@broadpeak/smartlib-v3": "^3.2.0-3317",
-    "core-js": "^3.11.0"
+    "@broadpeak/smartlib-v3": "^3.2.0-3317"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",

--- a/src/broadpeak.js
+++ b/src/broadpeak.js
@@ -1,7 +1,6 @@
 // @flow
 import {KalturaPlayer, BasePlugin, core} from 'kaltura-player-js';
-import {SmartLib} from '@broadpeak/smartlib-v3';
-import {LoggerManager} from '@broadpeak/smartlib-v3';
+import {SmartLib, LoggerManager} from '@broadpeak/smartlib-v3-nopolyfill';
 import {BPEngineDecorator} from './bp-engine-decorator';
 import {BPMiddleware} from './bp-middleware';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1714,10 +1714,10 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@broadpeak/smartlib-v3@^3.2.0-3317":
-  version "3.2.0-3317"
-  resolved "https://delivery-platform.broadpeak.tv/js/@broadpeak%2fsmartlib-v3/-/smartlib-v3-3.2.0-3317.tgz#e2aec30bfbe96c516600c85f5f24ec8c89ca1cf2"
-  integrity sha512-oTXlVoD576Qzp7UwZLHTF4IkxXdT6GUuG8/zkhNvENkSqCTojtqDYFPqzByGClWI33dt/KgAQ3YRaDPLboijUA==
+"@broadpeak/smartlib-v3-nopolyfill@^3.3.5.3791":
+  version "3.3.5-3791"
+  resolved "https://delivery-platform.broadpeak.tv/js/@broadpeak%2fsmartlib-v3-nopolyfill/-/smartlib-v3-nopolyfill-3.3.5-3791.tgz#3574f517cb8bd4786ddfc4d314e3d4adcabe40d7"
+  integrity sha512-NqzhzpBzRQrAMRKHE1FUEgnozN/Yy9m17lCj9ixl9J/5CfOQw1dLROmOvH5kY31o28aG1XlVlxaVSVw54gmqaw==
   dependencies:
     xmlhttprequest "^1.8.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3693,11 +3693,6 @@ core-js@^2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
-core-js@^3.11.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.11.0.tgz#05dac6aa70c0a4ad842261f8957b961d36eb8926"
-  integrity sha512-bd79DPpx+1Ilh9+30aT5O1sgpQd4Ttg8oqkqi51ZzhedMM1omD2e6IOF48Z/DzDCZ2svp49tN/3vneTK6ZBkXw==
-
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"


### PR DESCRIPTION
### Description of the Changes

core-js and the regular smartLib not supported on webos 3

Use smartLib non-polyfil lib instead of both

This reverts commit fa74117e79f879e2db21136e4f47d0d92fb2e40b.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
