### PR TITLE
fix(SUP-39906): pass error object in promise rejection

### DIFF
--- a/src/broadpeak.js
+++ b/src/broadpeak.js
@@ -176,9 +176,10 @@ class BroadPeak extends BasePlugin {
         this.dispatchEvent(this.player.Event.SOURCE_URL_SWITCHED, {originalUrl: playbackUrl, updatedUrl});
         this._srcPromise.resolve();
       } else {
-        this.logger.error('getUrl failed', result.getErrorCode(), result.getErrorMessage());
+        const errorMessage = `getUrl failed with error code: ${result.getErrorCode()}. error message: ${result.getErrorMessage()}`;
+        this.logger.error(errorMessage);
         this.reset();
-        this._srcPromise.reject();
+        this._srcPromise.reject(new Error(errorMessage));
       }
     });
   }


### PR DESCRIPTION
### Description of the Changes

Pass error object to promise rejection, when `getUrl` API fails.

Solves [SUP-39906](https://kaltura.atlassian.net/browse/SUP-39906)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[SUP-39906]: https://kaltura.atlassian.net/browse/SUP-39906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ